### PR TITLE
chore(deps): restore Go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/anchore/go-lzo
 
-go 1.26.2
+go 1.24.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.24.0 (pre-#37). Bumped in #37 (merge 547de57f5b9c939e7ceec4c5e28c15fe5fba5362).