### PR TITLE
Tighten workflow-level permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
+permissions: {}
 
 # there should never be two releases in progress at the same time
 concurrency:

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,8 +6,7 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -15,6 +14,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,6 +31,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Move top-level workflow permissions from `contents: read` to `{}` across all three workflows, pushing the required `contents: read` down to the job level where actually needed.

Changes:
- set `permissions: {}` at the top level of release.yaml, validate-github-actions.yaml, and validations.yaml
- add `permissions: { contents: read }` to the Static-Analysis and Unit-Test jobs in validations.yaml (the zizmor and release jobs already had explicit job-level permissions)

Notes:
- release.yaml structure is otherwise unchanged; no jobs were added or removed